### PR TITLE
Calls to bk_printf with logging strings need %s

### DIFF
--- a/src/logging/logging.c
+++ b/src/logging/logging.c
@@ -184,8 +184,7 @@ void addLogAdv(int level, int feature, char *fmt, ...)
             if (tmp[strlen(tmp)-1]=='\n') tmp[strlen(tmp)-1]='\0';
             if (tmp[strlen(tmp)-1]=='\r') tmp[strlen(tmp)-1]='\0';
 
-            bk_printf(tmp);
-            bk_printf("\r\n");
+            bk_printf("%s\r\n", tmp);
             if(g_extraSocketToSendLOG) 
             {
                 send(g_extraSocketToSendLOG,tmp,strlen(tmp),0);
@@ -314,7 +313,7 @@ void addLogAdv(int level, int feature, char *fmt, ...)
         }
 
         if (direct_serial_log){
-            bk_printf(tmp);
+            bk_printf("%s", tmp);
             if (taken == pdTRUE){
                 xSemaphoreGive( logMemory.mutex );
             }
@@ -513,7 +512,7 @@ static void log_serial_thread( beken_thread_arg_t arg )
     while ( 1 ){
         int count = getSerial(seriallogbuf, SERIALLOGBUFSIZE);
         if (count){
-            bk_printf(seriallogbuf);
+            bk_printf("%s", seriallogbuf);
         }
         rtos_delay_milliseconds(10);
     }


### PR DESCRIPTION
bk_printf expects a formatting string, so if you pass it a log entry with a "%" in it, it will not show the "%" symbol and instead try to match a formatting pattern. This causes a difference in logging to serial vs logging to TCP / HTTP. Eg, this code results in different results on serial vs other logging:

```
ADDLOGF_INFO("At %d%%", 12);
```

Expected: Log shows "At 12%" - actual serial log is "At 12".